### PR TITLE
Fix formatting of error message

### DIFF
--- a/lib/promisepay/error.rb
+++ b/lib/promisepay/error.rb
@@ -39,7 +39,7 @@ module Promisepay
       message = ''
       message << json_response['message'] if json_response.key?('message')
       if json_response.key?('errors')
-        message << json_response['errors'].map{|attribute, content| "#{attribute}: #{content.join(", ")}"}.join(", ")
+        message << json_response['errors'].map{|attribute, content| "#{attribute}: #{content}"}.join(", ")
       end
 
       message

--- a/lib/promisepay/error.rb
+++ b/lib/promisepay/error.rb
@@ -39,9 +39,7 @@ module Promisepay
       message = ''
       message << json_response['message'] if json_response.key?('message')
       if json_response.key?('errors')
-        json_response['errors'].each do |attribute, content|
-          message << "#{attribute}: #{content}"
-        end
+        message << json_response['errors'].map{|attribute, content| "#{attribute}: #{content.join(", ")}"}.join(", ")
       end
 
       message

--- a/spec/promisepay/error_spec.rb
+++ b/spec/promisepay/error_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Promisepay::Error do
+  describe "from_response" do
+    it "returns an error with formatted message" do
+      response = double(Faraday::Response, status: 422, body: "{\"errors\":{\"name\":[\"can't be blank\",\"required field missing\"],\"principal.firstname\":[\"can't be blank\"],\"principal.email\":[\"is invalid\"],\"principal.mobile\":[\"already exists\"],\"principal\":[\"is invalid\"]}}")
+      error = Promisepay::Error.from_response(response)
+      expect(error.message).to eq "name: can't be blank, required field missing, principal.firstname: can't be blank, principal.email: is invalid, principal.mobile: already exists, principal: is invalid"
+    end
+  end
+end

--- a/spec/promisepay/error_spec.rb
+++ b/spec/promisepay/error_spec.rb
@@ -5,7 +5,7 @@ describe Promisepay::Error do
     it "returns an error with formatted message" do
       response = double(Faraday::Response, status: 422, body: "{\"errors\":{\"name\":[\"can't be blank\",\"required field missing\"],\"principal.firstname\":[\"can't be blank\"],\"principal.email\":[\"is invalid\"],\"principal.mobile\":[\"already exists\"],\"principal\":[\"is invalid\"]}}")
       error = Promisepay::Error.from_response(response)
-      expect(error.message).to eq "name: can't be blank, required field missing, principal.firstname: can't be blank, principal.email: is invalid, principal.mobile: already exists, principal: is invalid"
+      expect(error.message).to eq "name: [\"can't be blank\", \"required field missing\"], principal.firstname: [\"can't be blank\"], principal.email: [\"is invalid\"], principal.mobile: [\"already exists\"], principal: [\"is invalid\"]"
     end
   end
 end


### PR DESCRIPTION
I just added some commas between the error attributes so that it's easier to read.

Old: 
```
"name: ["can't be blank", "required field missing"]principal.firstname: ["can't be blank"]principal.email: ["is invalid"]principal.mobile: ["already exists"]principal: ["is invalid"]"
```

New: 
```
"name: ["can't be blank", "required field missing"], principal.firstname: ["can't be blank"], principal.email: ["is invalid"], principal.mobile: ["already exists"], principal: ["is invalid"]"
```