### PR TITLE
Bank accounts#validate routing number

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ bank_account.deactivate
 ```ruby
 bank_account.user
 ```
+#####Validate Routing Number
+```ruby
+client.bank_accounts.validate('122235821')
+```
 
 ##PayPal Accounts
 #####Create a PayPal account

--- a/lib/promisepay/client.rb
+++ b/lib/promisepay/client.rb
@@ -55,9 +55,9 @@ module Promisepay
     # @param url [String] The path, relative to {#api_endpoint}
     # @param parameters [Hash] Query params for request
     # @return [Faraday::Response]
-    def get(url, parameters = {})
+    def get(url, parameters = {}, skip_status_check = false)
       response = connection.get("#{api_endpoint}#{url}", parameters)
-      on_complete(response)
+      on_complete(response) unless skip_status_check
       response
     end
 

--- a/lib/promisepay/resources/bank_account_resource.rb
+++ b/lib/promisepay/resources/bank_account_resource.rb
@@ -28,5 +28,23 @@ module Promisepay
       response = JSON.parse(@client.post('bank_accounts', attributes).body)
       Promisepay::BankAccount.new(@client, response['bank_accounts'])
     end
+
+    # Validate a US bank routing number before creating an account.
+    # This can be used to provide on-demand verification,
+    # and further information of the bank information a User is providing.
+    #
+    # @see https://reference.promisepay.com/#validate-routing-number
+    #
+    # @param routing_number [String] Bank account Routing Number
+    #
+    # @return [Hash]
+    def validate(routing_number)
+      response = @client.get('tools/routing_number', { routing_number: routing_number }, true)
+      if response.status == 200
+        JSON.parse(response.body)['routing_number']
+      else
+        nil
+      end
+    end
   end
 end

--- a/lib/promisepay/resources/bank_account_resource.rb
+++ b/lib/promisepay/resources/bank_account_resource.rb
@@ -40,11 +40,7 @@ module Promisepay
     # @return [Hash]
     def validate(routing_number)
       response = @client.get('tools/routing_number', { routing_number: routing_number }, true)
-      if response.status == 200
-        JSON.parse(response.body)['routing_number']
-      else
-        nil
-      end
+      (response.status == 200) ? JSON.parse(response.body)['routing_number'] : {}
     end
   end
 end

--- a/spec/fixtures/bank_accounts_validate_invalid_number.yml
+++ b/spec/fixtures/bank_accounts_validate_invalid_number.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/tools/routing_number?routing_number=111
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 22 May 2016 10:27:45 GMT
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Status:
+      - 404 Not Found
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - 7605d340-3d09-4b2e-a9af-bd605b1c5fe8
+      X-Runtime:
+      - '0.324468'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: 'null'
+    http_version: 
+  recorded_at: Sun, 22 May 2016 10:27:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/bank_accounts_validate_valid_number.yml
+++ b/spec/fixtures/bank_accounts_validate_valid_number.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/tools/routing_number?routing_number=122235821
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 22 May 2016 10:27:44 GMT
+      Etag:
+      - W/"faea47bb620de3fe0e46492f9bcaa2e7"
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - 421331a8-92da-47e9-a11c-a89b87c3b739
+      X-Runtime:
+      - '0.314172'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"routing_number":{"routing_number":"122235821","customer_name":"US
+        BANK NA","address":"EP-MN-WN1A","city":"ST. PAUL","state_code":"MN","zip":"55107","zip_extension":"1419","phone_area_code":"800","phone_prefix":"937","phone_suffix":"6310"}}'
+    http_version: 
+  recorded_at: Sun, 22 May 2016 10:27:44 GMT
+recorded_with: VCR 2.9.3

--- a/spec/promisepay/resources/bank_account_resource_spec.rb
+++ b/spec/promisepay/resources/bank_account_resource_spec.rb
@@ -83,9 +83,10 @@ describe Promisepay::BankAccountResource do
     end
     context 'with an invalid routing number', vcr: { cassette_name: 'bank_accounts_validate_invalid_number' } do
       let(:routing_number) { '111' }
-      it 'returns nil' do
+      it 'returns an empty hash' do
         info = client.bank_accounts.validate(routing_number)
-        expect(info).to be_nil
+        expect(info).to be_a(Hash)
+        expect(info).to be_empty
       end
     end
   end

--- a/spec/promisepay/resources/bank_account_resource_spec.rb
+++ b/spec/promisepay/resources/bank_account_resource_spec.rb
@@ -63,6 +63,33 @@ describe Promisepay::BankAccountResource do
     end
   end
 
+  describe 'validate' do
+    context 'with a valid routing number', vcr: { cassette_name: 'bank_accounts_validate_valid_number' } do
+      let(:routing_number) { '122235821' }
+      it 'returns account information' do
+        info = client.bank_accounts.validate(routing_number)
+        expect(info).to be_a(Hash)
+        expect(info).to have_key('routing_number')
+        expect(info).to have_key('customer_name')
+        expect(info).to have_key('address')
+        expect(info).to have_key('city')
+        expect(info).to have_key('state_code')
+        expect(info).to have_key('zip')
+        expect(info).to have_key('zip_extension')
+        expect(info).to have_key('phone_area_code')
+        expect(info).to have_key('phone_prefix')
+        expect(info).to have_key('phone_suffix')
+      end
+    end
+    context 'with an invalid routing number', vcr: { cassette_name: 'bank_accounts_validate_invalid_number' } do
+      let(:routing_number) { '111' }
+      it 'returns nil' do
+        info = client.bank_accounts.validate(routing_number)
+        expect(info).to be_nil
+      end
+    end
+  end
+
   describe 'bank_account methods' do
     it 'can be accessed' do
       expect(client.bank_accounts.respond_to?(:user)).to be(true)


### PR DESCRIPTION
### Work
Adds [validate bank account routing number](https://reference.promisepay.com/#validate-routing-number) ability to SDK.

### Code snippet
```ruby
client = Promisepay::Client.new

client.bank_accounts.validate('122235821')
 => {"routing_number"=>"122235821", "customer_name"=>"US BANK NA", "address"=>"EP-MN-WN1A", "city"=>"ST. PAUL", "state_code"=>"MN", "zip"=>"55107", "zip_extension"=>"1419", "phone_area_code"=>"800", "phone_prefix"=>"937", "phone_suffix"=>"6310"} 

client.bank_accounts.validate('000')
 => {} 
```
 
### Notes
`GET /status` endpoint is listed on the documentation whereas the actual endpoint (used in the cURL example request) is `GET /tools/routing_number` 