### PR TITLE
Addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ user.bank_account
 ```ruby
 user.items
 ```
+#####Get a user's address
+```ruby
+user.address
+```
 #####Set a user's disbursement account
 ```ruby
 user.disbursement_account(bank_account.id)
@@ -376,6 +380,11 @@ client.companies.find('compamy_id')
 #####Get a list of companies
 ```ruby
 client.companies.find_all
+```
+
+#####Get a company's address
+```ruby
+company.address
 ```
 
 #####Update a company

--- a/lib/promisepay/models/company.rb
+++ b/lib/promisepay/models/company.rb
@@ -4,12 +4,23 @@ module Promisepay
 
   	# Get the user the company belongs to.
     #
-    # @see 
+    # @see
     #
     # @return [Promisepay::User]
     def user
       response = JSON.parse(@client.get("companies/#{send(:id)}/users").body)
       Promisepay::User.new(@client, response['users'])
+    end
+
+    # Gets company address.
+    #
+    # @see https://reference.promisepay.com/#addresses
+    #
+    # @return [Hash]
+    def address
+      return nil unless @attributes.key?('related')
+      response = JSON.parse(@client.get("addresses/#{send(:related)['addresses']}").body)
+      response['addresses']
     end
   end
 end

--- a/lib/promisepay/models/user.rb
+++ b/lib/promisepay/models/user.rb
@@ -71,5 +71,16 @@ module Promisepay
     rescue Promisepay::NotFound
       nil
     end
+
+    # Gets user address.
+    #
+    # @see https://reference.promisepay.com/#addresses
+    #
+    # @return [Hash]
+    def address
+      return nil unless @attributes.key?('related')
+      response = JSON.parse(@client.get("addresses/#{send(:related)['addresses']}").body)
+      response['addresses']
+    end
   end
 end

--- a/spec/fixtures/company_address.yml
+++ b/spec/fixtures/company_address.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/users
+    body:
+      encoding: UTF-8
+      string: '{"id":"7b3b8597-1c12-4124-8bc8-d7f2ff73b158","first_name":"myFirstName","email":"7b3b8597-1c12-4124-8bc8-d7f2ff73b158@mail.com","country":"AUS"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 07 Jun 2016 20:11:13 GMT
+      Etag:
+      - W/"7e93f642949a7f7085cfef1087c8e780"
+      Location:
+      - "/users/7b3b8597-1c12-4124-8bc8-d7f2ff73b158"
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Set-Cookie:
+      - request_method=POST; path=/
+      Status:
+      - 201 Created
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - a9661204-8bfe-4ff5-b589-ce1b9dffaa71
+      X-Runtime:
+      - '1.289299'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"users":{"created_at":"2016-06-07T20:11:12.690Z","updated_at":"2016-06-07T20:11:12.690Z","full_name":"myFirstName","email":"7b3b8597-1c12-4124-8bc8-d7f2ff73b158@mail.com","mobile":null,"phone":null,"logo_url":null,"color_1":null,"color_2":null,"first_name":"myFirstName","last_name":null,"id":"7b3b8597-1c12-4124-8bc8-d7f2ff73b158","location":"AUS","verification_state":"pending","held_state":false,"dob":null,"government_number":null,"drivers_license":null,"flags":{},"related":{"addresses":"fd0053a3-538f-4770-8827-3de9aa761903"},"links":{"self":"/users","items":"/users/7b3b8597-1c12-4124-8bc8-d7f2ff73b158/items","card_accounts":"/users/7b3b8597-1c12-4124-8bc8-d7f2ff73b158/card_accounts","paypal_accounts":"/users/7b3b8597-1c12-4124-8bc8-d7f2ff73b158/paypal_accounts","bank_accounts":"/users/7b3b8597-1c12-4124-8bc8-d7f2ff73b158/bank_accounts","wallet_accounts":"/users/7b3b8597-1c12-4124-8bc8-d7f2ff73b158/wallet_accounts"}}}'
+    http_version: 
+  recorded_at: Tue, 07 Jun 2016 20:11:13 GMT
+- request:
+    method: get
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/addresses/fd0053a3-538f-4770-8827-3de9aa761903
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 07 Jun 2016 20:11:14 GMT
+      Etag:
+      - W/"bba74069164d467a3d153d0a4141fe3a"
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - 35afac79-a4c1-411f-8807-f5af9782fba0
+      X-Runtime:
+      - '0.319951'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"addresses":{"addressline1":null,"addressline2":null,"postcode":null,"city":null,"state":null,"id":"fd0053a3-538f-4770-8827-3de9aa761903","country":"Australia","links":{"self":"/addresses/fd0053a3-538f-4770-8827-3de9aa761903"}}}'
+    http_version: 
+  recorded_at: Tue, 07 Jun 2016 20:11:15 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/users_address.yml
+++ b/spec/fixtures/users_address.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/users
+    body:
+      encoding: UTF-8
+      string: '{"id":"71422140-341f-4bfb-9cd1-e0c6cf895ec6","first_name":"myFirstName","email":"71422140-341f-4bfb-9cd1-e0c6cf895ec6@mail.com","country":"AUS"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 07 Jun 2016 20:07:22 GMT
+      Etag:
+      - W/"cd541fe19fb69968af0918d1535157ec"
+      Location:
+      - "/users/71422140-341f-4bfb-9cd1-e0c6cf895ec6"
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Set-Cookie:
+      - request_method=POST; path=/
+      Status:
+      - 201 Created
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - fe96ffcd-340c-4c24-afa9-65fd883aa7f2
+      X-Runtime:
+      - '0.841754'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"users":{"created_at":"2016-06-07T20:07:22.211Z","updated_at":"2016-06-07T20:07:22.211Z","full_name":"myFirstName","email":"71422140-341f-4bfb-9cd1-e0c6cf895ec6@mail.com","mobile":null,"phone":null,"logo_url":null,"color_1":null,"color_2":null,"first_name":"myFirstName","last_name":null,"id":"71422140-341f-4bfb-9cd1-e0c6cf895ec6","location":"AUS","verification_state":"pending","held_state":false,"dob":null,"government_number":null,"drivers_license":null,"flags":{},"related":{"addresses":"1ab68245-3c30-49b8-8131-974ddb2f890b"},"links":{"self":"/users","items":"/users/71422140-341f-4bfb-9cd1-e0c6cf895ec6/items","card_accounts":"/users/71422140-341f-4bfb-9cd1-e0c6cf895ec6/card_accounts","paypal_accounts":"/users/71422140-341f-4bfb-9cd1-e0c6cf895ec6/paypal_accounts","bank_accounts":"/users/71422140-341f-4bfb-9cd1-e0c6cf895ec6/bank_accounts","wallet_accounts":"/users/71422140-341f-4bfb-9cd1-e0c6cf895ec6/wallet_accounts"}}}'
+    http_version: 
+  recorded_at: Tue, 07 Jun 2016 20:07:22 GMT
+- request:
+    method: get
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/addresses/1ab68245-3c30-49b8-8131-974ddb2f890b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 07 Jun 2016 20:07:23 GMT
+      Etag:
+      - W/"eede95ee30dae92d3a7c2d299dc479c1"
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - 437b1b8f-6f86-48fb-b487-e784d03ab60e
+      X-Runtime:
+      - '0.327113'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"addresses":{"addressline1":null,"addressline2":null,"postcode":null,"city":null,"state":null,"id":"1ab68245-3c30-49b8-8131-974ddb2f890b","country":"Australia","links":{"self":"/addresses/1ab68245-3c30-49b8-8131-974ddb2f890b"}}}'
+    http_version: 
+  recorded_at: Tue, 07 Jun 2016 20:07:23 GMT
+recorded_with: VCR 2.9.3

--- a/spec/promisepay/models/company_spec.rb
+++ b/spec/promisepay/models/company_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe Promisepay::Company do
-  let(:client) { Promisepay::Client.new }
-  let(:company) { VCR.use_cassette('companies_multiple') { client.companies.find_all.first } }
+  let(:company) { PromisepayFactory.create_user }
 
+  describe 'address', vcr: { cassette_name: 'company_address'} do
+    it 'returns a Hash' do
+      address = company.address
+      expect(address).to be_a(Hash)
+      expect(address).to have_key('addressline1')
+      expect(address).to have_key('country')
+    end
+  end
 end

--- a/spec/promisepay/models/user_spec.rb
+++ b/spec/promisepay/models/user_spec.rb
@@ -87,4 +87,14 @@ describe Promisepay::User do
       expect(user.disbursement_account(bank_account.id)).to be(true)
     end
   end
+
+  describe 'address', vcr: { cassette_name: 'users_address'} do
+    let(:user) { PromisepayFactory.create_user }
+    it 'returns a Hash' do
+      address = user.address
+      expect(address).to be_a(Hash)
+      expect(address).to have_key('addressline1')
+      expect(address).to have_key('country')
+    end
+  end
 end

--- a/spec/support/promisepay_factory.rb
+++ b/spec/support/promisepay_factory.rb
@@ -50,6 +50,24 @@ module PromisepayFactory
     client.fees.create(default_options.merge(options))
   end
 
+  def self.create_company options={}
+    default_options = {
+      name: "Samuel's Gardening",
+      legal_name: "Samuel's Gardening Pty Ltd",
+      user_id: '',
+      tax_number: '100200300',
+      charge_tax: false,
+      address_line1: '500 Garden St',
+      address_line2: '',
+      city: 'Sydney',
+      state: 'NSW',
+      zip: '2000',
+      country: 'AUS',
+      phone: '+61491570156'
+    }
+    client.companies.create(default_options.merge(options))
+  end
+
   private
 
   def self.client


### PR DESCRIPTION
### Work
Adds [addresses](https://reference.promisepay.com/?ruby#addresses) information to users and companies.

### Code snippet
```ruby
client = Promisepay::Client.new
user = client.users.find_all.last
company = client.companies.find_all.last

# When address info are not available
user.address
=> nil
company.address
=> nil

# When address info are available
user.address
=> { "addressline1"=>"100 Main Street", "addressline2"=>"", "postcode"=>"2000", "city"=>"Sydney", "state"=>"NSW", "country"=>"Australia" }
company.address
=> { "addressline1"=>"100 Main Street", "addressline2"=>"", "postcode"=>"2000", "city"=>"Sydney", "state"=>"NSW", "country"=>"Australia" }
```