### PR TITLE
Fixed company and user update methods for each model

### DIFF
--- a/lib/promisepay/models/company.rb
+++ b/lib/promisepay/models/company.rb
@@ -1,6 +1,18 @@
 module Promisepay
   # Manage Companies
   class Company < BaseModel
+    # Update the attributes of an item.
+    #
+    # @see https://reference.promisepay.com/#update-item
+    #
+    # @param attributes [Hash] Item's attributes to be updated.
+    #
+    # @return [self]
+    def update(attributes)
+      response = JSON.parse(@client.patch("companies/#{send(:id)}", attributes).body)
+      @attributes = response['companies']
+      self
+    end
 
   	# Get the user the company belongs to.
     #

--- a/lib/promisepay/models/user.rb
+++ b/lib/promisepay/models/user.rb
@@ -2,6 +2,19 @@
 module Promisepay
   # Manage Users
   class User < BaseModel
+    # Update the attributes of an item.
+    #
+    # @see https://reference.promisepay.com/#update-item
+    #
+    # @param attributes [Hash] Item's attributes to be updated.
+    #
+    # @return [self]
+    def update(attributes)
+      response = JSON.parse(@client.patch("users/#{send(:id)}", attributes).body)
+      @attributes = response['users']
+      self
+    end
+
     # Lists items for a user on a marketplace.
     #
     # @see https://reference.promisepay.com/#list-user-items


### PR DESCRIPTION
The update methods for company and user did not pass the ID for them through the URL, they did it through the body.

This change allows an update call to occur, with the ID in the URL.