### PR TITLE
Payment restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,16 @@ client.marketplace
 client.generate_token(token_type: 'card', user_id: '5830def0-ffe8-11e5-86aa-5e5517507c66')
 ```
 
+##Payment restriction
+#####Get a list of payment restrictions
+```ruby
+client.payment_restrictions.find_all
+```
+#####Get a payment restriction
+```ruby
+client.payment_restrictions.find("12a7732c-87a8-432d-a814-b53c1586ec3c")
+```
+
 _Check out the [online documentation](http://promisepay.github.io/promisepay-ruby/) to get a full list of available resources and methods._
 
 #4. Contributing

--- a/lib/promisepay/client.rb
+++ b/lib/promisepay/client.rb
@@ -9,6 +9,7 @@ require_relative 'models/company'
 require_relative 'models/direct_debit_authority'
 require_relative 'models/fee'
 require_relative 'models/item'
+require_relative 'models/payment_restriction'
 require_relative 'models/paypal_account'
 require_relative 'models/transaction'
 require_relative 'models/user'
@@ -22,6 +23,7 @@ require_relative 'resources/company_resource'
 require_relative 'resources/fee_resource'
 require_relative 'resources/direct_debit_authority_resource'
 require_relative 'resources/item_resource'
+require_relative 'resources/payment_restriction_resource'
 require_relative 'resources/paypal_account_resource'
 require_relative 'resources/token_resource'
 require_relative 'resources/transaction_resource'
@@ -134,6 +136,7 @@ module Promisepay
         direct_debit_authorities: DirectDebitAuthorityResource,
         fees: FeeResource,
         items: ItemResource,
+        payment_restrictions: PaymentRestrictionResource,
         paypal_accounts: PaypalAccountResource,
         transactions: TransactionResource,
         users: UserResource,

--- a/lib/promisepay/models/payment_restriction.rb
+++ b/lib/promisepay/models/payment_restriction.rb
@@ -1,0 +1,5 @@
+module Promisepay
+  # Manage Payment Restriction
+  class PaymentRestriction < BaseModel
+  end
+end

--- a/lib/promisepay/resources/payment_restriction_resource.rb
+++ b/lib/promisepay/resources/payment_restriction_resource.rb
@@ -1,0 +1,39 @@
+module Promisepay
+  # Resource for the Payement Restrictions API
+  class PaymentRestrictionResource < BaseResource
+    def model
+      Promisepay::PaymentRestriction
+    end
+
+    # List all payment restrictions
+    #
+    # @see https://reference.promisepay.com/#list-payment-restrictions
+    #
+    # @param options [Hash] Optional options.
+    # @option options [Integer] :limit Can ask for up to 200 payment_restrictions. default: 10
+    # @option options [Integer] :offset Pagination help. default: 0
+    # @option options [String] :search Search string.
+    # @option options [String] :user_id User ID to specify, if any.
+    # @option options [String] :item_id Item ID to specify, if any.
+    # @option options [String] :country Country to specify, if any.
+    #
+    # @return [Array<Promisepay::PaymentRestriction>] List all payment restrictions for a marketplace.
+    def find_all(options = {})
+      response = JSON.parse(@client.get('payment_restrictions', options).body)
+      payment_restrictions = response.key?('payment_restrictions') ? response['payment_restrictions'] : []
+      payment_restrictions.map { |attributes| Promisepay::PaymentRestriction.new(@client, attributes) }
+    end
+
+    # Get a single payment restriction for a marketplace
+    #
+    # @see https://reference.prelive.promisepay.com/#show-payment-restriction
+    #
+    # @param id [String] Marketplace PaymentRestriction ID.
+    #
+    # @return [Promisepay::PaymentRestriction]
+    def find(id)
+      response = JSON.parse(@client.get("payment_restrictions/#{id}").body)
+      Promisepay::PaymentRestriction.new(@client, response['payment_restrictions'])
+    end
+  end
+end

--- a/spec/fixtures/payment_restrictions_empty.yml
+++ b/spec/fixtures/payment_restrictions_empty.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<USERNAME>:<TOKEN>@test.api.promisepay.com/payment_restrictions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Content-Type, Accept, Authorization, Token
+      Access-Control-Allow-Methods:
+      - POST, GET, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '1728000'
+      Access-Control-Request-Method:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 28 Aug 2016 13:52:01 GMT
+      Etag:
+      - W/"9113aded8314bc96d8df07efa1051323"
+      Location:
+      - "/payment_restrictions"
+      Server:
+      - nginx/1.8.0 + Phusion Passenger 4.0.59
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Powered-By:
+      - Phusion Passenger 4.0.59
+      X-Request-Id:
+      - e6fca755-6d55-4b4b-960f-635b35ebf7ef
+      X-Runtime:
+      - '0.350476'
+      X-Xss-Protection:
+      - 1; mode=block
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"meta":{"limit":10,"offset":0,"total":0}}'
+    http_version: 
+  recorded_at: Sun, 28 Aug 2016 13:52:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/promisepay/resources/payment_restriction_resource_spec.rb
+++ b/spec/promisepay/resources/payment_restriction_resource_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Promisepay::PaymentRestrictionResource do
+  let(:client) { Promisepay::Client.new }
+
+  describe 'find_all' do
+    subject { client.payment_restrictions.find_all }
+    context 'when no payment restrictions are available', vcr: { cassette_name: 'payment_restrictions_empty' } do
+      it { is_expected.to be_empty }
+    end
+
+    # context 'when multiple payment restrictions are available', vcr: { cassette_name: 'payment_restrictions_multiple' } do
+    #   before { PromisepayFactory.create_payment_restriction }
+
+    #   it 'gives back an array of payment_restrictions' do
+    #     expect(subject).to_not be_empty
+    #     expect(subject.first).to be_kind_of(Promisepay::PaymentRestriction)
+    #   end
+    # end
+  end
+
+  describe 'find' do
+    # context 'an existing item', vcr: { cassette_name: 'payment_restrictions_single' } do
+    #   let(:payment_restriction) { PromisepayFactory.create_payment_restriction }
+    #   it 'gives back a single item' do
+    #     item = client.payment_restrictions.find(payment_restriction.id)
+    #     expect(item).to be_a(Promisepay::Item)
+    #   end
+    # end
+
+    # context 'an unknown item', vcr: { cassette_name: 'payment_restrictions_unknown' } do
+    #   it 'raises an error' do
+    #     expect { client.payment_restrictions.find('unkown_id') }.to raise_error(Promisepay::Unauthorized)
+    #   end
+    # end
+  end
+end


### PR DESCRIPTION
### Work

Adds [Payment Restrictions](https://reference.prelive.promisepay.com/#payment-restrictions) to client.
### Code snippet

``` ruby

# Retrieve restrictions
client.payment_restrictions.find_all(user_id: '5830def0-ffe8-11e5-86aa-5e5517507c66')
#=> Array<Promisepay::PaymentRestriction>

# Retrieve existing restriction
client.payment_restrictions.find(12a7732c-87a8-432d-a814-b53c1586ec3c')
#=> Promisepay::PaymentRestriction
```
