### PR TITLE
Transaction accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,22 @@ transaction.users
 ```ruby
 transaction.fees
 ```
+#####Get a transaction's bank account
+```ruby
+transaction.bank_account
+```
+#####Get a transaction's card account
+```ruby
+transaction.card_account
+```
+#####Get a transaction's Paypal account
+```ruby
+transaction.paypal_account
+```
+#####Get a transaction's wallet account
+```ruby
+transaction.wallet_account
+```
 
 ##Charges
 #####Get a list of charges

--- a/lib/promisepay/models/transaction.rb
+++ b/lib/promisepay/models/transaction.rb
@@ -20,5 +20,45 @@ module Promisepay
       response = JSON.parse(@client.get("transactions/#{send(:id)}/fees").body)
       response.key?('fees') ? Promisepay::Fee.new(@client, response['fees']) : nil
     end
+
+    # Show the Bank Account associated with the Transaction.
+    #
+    # @see https://reference.promisepay.com/#show-transaction-bank-account
+    #
+    # @return [Promisepay::BankAccount]
+    def bank_account
+      response = JSON.parse(@client.get("transactions/#{send(:id)}/bank_accounts").body)
+      response.key?('bank_accounts') ? Promisepay::BankAccount.new(@client, response['bank_accounts']) : nil
+    end
+
+    # Show the Card Account associated with the Transaction.
+    #
+    # @see https://reference.promisepay.com/#show-transaction-card-account
+    #
+    # @return [Promisepay::CardAccount]
+    def card_account
+      response = JSON.parse(@client.get("transactions/#{send(:id)}/card_accounts").body)
+      response.key?('card_accounts') ? Promisepay::CardAccount.new(@client, response['card_accounts']) : nil
+    end
+
+    # Show the Paypal Account associated with the Transaction.
+    #
+    # @see https://reference.promisepay.com/#show-transaction-paypal-account
+    #
+    # @return [Promisepay::PaypalAccount]
+    def paypal_account
+      response = JSON.parse(@client.get("transactions/#{send(:id)}/paypal_accounts").body)
+      response.key?('paypal_accounts') ? Promisepay::PaypalAccount.new(@client, response['paypal_accounts']) : nil
+    end
+
+    # Show the Wallet Account associated with the Transaction.
+    #
+    # @see https://reference.promisepay.com/#show-transaction-wallet-account
+    #
+    # @return [Promisepay::WalletAccount]
+    def wallet_account
+      response = JSON.parse(@client.get("transactions/#{send(:id)}/wallet_accounts").body)
+      response.key?('wallet_accounts') ? Promisepay::WalletAccount.new(@client, response['wallet_accounts']) : nil
+    end
   end
 end

--- a/spec/promisepay/models/transaction_spec.rb
+++ b/spec/promisepay/models/transaction_spec.rb
@@ -34,11 +34,15 @@ describe Promisepay::Transaction do
     let(:seller) { PromisepayFactory.create_user }
     let(:item) { PromisepayFactory.create_item({}, seller, buyer) }
     let(:transaction) { item.transactions.last }
-    before { item.make_payment(account_id: account.id) }
-
 
     # describe 'bank_account', vcr: { cassette_name: 'transactions_bank_account' } do
     #   let(:account) { PromisepayFactory.create_bank_account({}, buyer) }
+    #   before do
+    #     buyer.disbursement_account(account_id: account.id)
+    #     client.direct_debit_authorities.create(account_id: account.id, amount: '10000')
+    #     item.make_payment(account_id: account.id)
+    #   end
+
     #   subject { transaction.bank_account }
 
     #   it { is_expected.to be_a(Promisepay::BankAccount) }
@@ -46,13 +50,15 @@ describe Promisepay::Transaction do
 
     # describe 'card_account', vcr: { cassette_name: 'transactions_card_account' } do
     #   let(:account) { PromisepayFactory.create_card_account({}, buyer) }
+    #   before { item.make_payment(account_id: account.id) }
     #   subject { transaction.card_account }
 
     #   it { is_expected.to be_a(Promisepay::CardAccount) }
     # end
 
     # describe 'wallet_account', vcr: { cassette_name: 'transactions_wallet_account' } do
-    #   let(:account) { PromisepayFactory.create_wallet_account({}, buyer) }
+    #   let(:account) { buyer.wallet_account }
+    #   before { item.make_payment(account_id: account.id) }
     #   subject { transaction.wallet_account }
 
     #   it { is_expected.to be_a(Promisepay::WalletAccount) }
@@ -60,6 +66,7 @@ describe Promisepay::Transaction do
 
     # describe 'paypal_account', vcr: { cassette_name: 'transactions_paypal_account' } do
     #   let(:account) { PromisepayFactory.create_paypal_account({}, buyer) }
+    #   before { item.make_payment(account_id: account.id) }
     #   subject { transaction.paypal_account }
 
     #   it { is_expected.to be_a(Promisepay::PaypalAccount) }

--- a/spec/promisepay/models/transaction_spec.rb
+++ b/spec/promisepay/models/transaction_spec.rb
@@ -28,4 +28,41 @@ describe Promisepay::Transaction do
       # end
     end
   end
+
+  describe 'accounts' do
+    let(:buyer) { PromisepayFactory.create_user }
+    let(:seller) { PromisepayFactory.create_user }
+    let(:item) { PromisepayFactory.create_item({}, seller, buyer) }
+    let(:transaction) { item.transactions.last }
+    before { item.make_payment(account_id: account.id) }
+
+
+    # describe 'bank_account', vcr: { cassette_name: 'transactions_bank_account' } do
+    #   let(:account) { PromisepayFactory.create_bank_account({}, buyer) }
+    #   subject { transaction.bank_account }
+
+    #   it { is_expected.to be_a(Promisepay::BankAccount) }
+    # end
+
+    # describe 'card_account', vcr: { cassette_name: 'transactions_card_account' } do
+    #   let(:account) { PromisepayFactory.create_card_account({}, buyer) }
+    #   subject { transaction.card_account }
+
+    #   it { is_expected.to be_a(Promisepay::CardAccount) }
+    # end
+
+    # describe 'wallet_account', vcr: { cassette_name: 'transactions_wallet_account' } do
+    #   let(:account) { PromisepayFactory.create_wallet_account({}, buyer) }
+    #   subject { transaction.wallet_account }
+
+    #   it { is_expected.to be_a(Promisepay::WalletAccount) }
+    # end
+
+    # describe 'paypal_account', vcr: { cassette_name: 'transactions_paypal_account' } do
+    #   let(:account) { PromisepayFactory.create_paypal_account({}, buyer) }
+    #   subject { transaction.paypal_account }
+
+    #   it { is_expected.to be_a(Promisepay::PaypalAccount) }
+    # end
+  end
 end

--- a/spec/support/promisepay_factory.rb
+++ b/spec/support/promisepay_factory.rb
@@ -57,6 +57,16 @@ module PromisepayFactory
     client.bank_accounts.create(default_options.merge(options))
   end
 
+  def self.create_paypal_account options={}, owner=nil
+    owner = create_user if owner.nil?
+
+    default_options = {
+      user_id: owner.id,
+      paypal_email: owner.email
+    }
+    client.paypal_accounts.create(default_options.merge(options))
+  end
+
   def self.create_fee options={}
     default_options = {
       fee_type_id: '1', # Fixed


### PR DESCRIPTION
### Work

Get account details from [transactions](https://reference.prelive.promisepay.com/#transactions).
### Code snippet

``` ruby
transaction = client.transactions.find_all.last

transaction.bank_account
#=> Promisepay::BankAccount or nil 
transaction.card_account
#=> Promisepay::CardAccount or nil 
transaction.paypal_account
#=> Promisepay::PaypalAccount or nil 
transaction.wallet_account
#=> Promisepay::WalletAccount or nil 
```
